### PR TITLE
Chore: application-secret.properties를 optional로 로드 및 CI/CD 워크플로 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,24 +9,20 @@ jobs:
     concurrency:
       group: "deploy-${{ github.ref_name }}"
       cancel-in-progress: true
-
     steps:
       - uses: actions/checkout@v4
-
-      # 1) Koyeb CLI 설치+인증 (Secrets에 KOYEB_API_TOKEN 이미 넣었음)
       - name: Configure Koyeb
         uses: koyeb-community/koyeb-actions@v2
         with:
           api_token: ${{ secrets.KOYEB_API_TOKEN }}
-
-      # 2) 저장소를 Buildpacks로 빌드 & 배포 (Docker 안 씀)
       - name: Build and Deploy
         uses: koyeb/action-git-deploy@v1
         with:
-          app-name: springboot-app          # 처음 배포 시 앱 자동 생성
-          service-name: mute-api                  # 서비스 이름
-          git-builder: buildpack             # ★ 도커 대신 Buildpacks
-          service-env: "JAVA_OPTS=-Xms256m -Xmx512m"
-          service-ports: "8080:http"         # 앱 내부 포트
-          service-routes: "/:8080"           # 외부 라우팅
-          service-checks: "8080:http:/actuator/health"  # Actuator 있으면 권장
+          app-name: springboot-app     #처음 배포 시 앱 자동 생성
+          service-name: mute-api       #서비스 이름
+          git-builder: buildpack       #도커 대신 Buildpacks
+          git-root: back-end
+          service-ports: "8080:http"
+          service-routes: "/:8080"
+          service-checks: "8080:http:/"
+          service-env: "JAVA_OPTS=-Xms256m -Xmx512m,SPRING_PROFILES_ACTIVE=cloud"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: 'temurin'
           java-version: '17'
           cache: gradle
-      - name: Build (Gradle)
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+      - name: Build
         if: hashFiles('gradlew') != ''
         run: ./gradlew build --no-daemon
       - name: Build (Maven)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 #import application-secret.properties
 spring.config.import=optional:classpath:application-secret.properties
 
+server.port=${PORT:8080}


### PR DESCRIPTION
## 📝 작업 내용

> application-secret.properties를 optional로 로드 및 CI/CD 워크플로 수정
- application-secret.properties를 선택적 로드로 변경하여 로컬·배포 환경 모두 지원
- gradlew 실행 권한 문제 해결 및 CI/CD 워크플로 환경 변수 수정