### PR TITLE
Fix: Koyeb 배포 스크립트 오류 수정 및 UNHEALTHY 대비

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
     steps:
       - uses: actions/checkout@v4
 
@@ -29,12 +30,13 @@ jobs:
           KOYEB_TOKEN: ${{ secrets.KOYEB_API_TOKEN }}
         run: |
           koyeb service update my-spring-app/mute-api \
-            --git github.com/Team-Mute/back-end \
+            --git https://github.com/Team-Mute/back-end \
             --git-branch main \
             --git-builder buildpack \
             --type web \
             --instance-type micro \
             --regions tyo \
+            --region '!fra' \
             --env SPRING_PROFILES_ACTIVE=ci \
             --env BP_JVM_VERSION=17 \
             --env SPRING_DATASOURCE_URL=${{ secrets.NEON_JDBC_URL }} \
@@ -45,7 +47,7 @@ jobs:
             --env AWS_REGION=${{ secrets.AWS_REGION }} \
             --env AWS_STACK_AUTO=${{ secrets.AWS_STACK_AUTO }} \
             --env AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }} \
-            --env JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -Xms128m -Xmx256m" \
+            --env JAVA_TOOL_OPTIONS='-XX:MaxRAMPercentage=75.0 -Xms128m -Xmx256m' \
             --ports 8080:http \
             --routes /:8080 \
-            --checks "8080:http:/actuator/health"
+            --checks "8080:http:/actuator/health?grace=30s&interval=10s"


### PR DESCRIPTION
## 📝 작업 내용
>Koyeb 배포 스크립트 오류 수정 및 UNHEALTHY 대비

- JAVA_TOOL_OPTIONS를 작은따옴표로 감싸 멀티라인 파싱 오류 방지
- --region '!fra' 옵션 추가로 불필요한 FRA 리전 제거
- --git URL을 전체 경로(https://)로 변경
- 헬스체크에 grace=30s&interval=10s 적용하여 초기 부팅 지연 대응

